### PR TITLE
Add crates.io deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-crates-io.yml
+++ b/.github/workflows/deploy-to-crates-io.yml
@@ -1,0 +1,24 @@
+name: Deploy to crates.io
+
+on:
+  push:
+    tags:
+    - '*'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libxdo-dev
+    - name: Publish to crates.io
+      uses: actions-rs/cargo@v1
+      with:
+        command: publish
+        args: --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
This is currently blocked on `druid` releasing a new version since we cannot pin Git revisions in published crates.